### PR TITLE
Issue 11: En passant fix

### DIFF
--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -4,7 +4,8 @@
 //
 //  Created by Alexander Perechnev, 2020.
 //  Modified by Nikolay Vorobyev, 2021.
-//  Copyright © 2020 Päike Mikrosüsteemid OÜ. All rights reserved.
+//  Modified by Alexander Perechnev, 2025.
+//  Copyright © 2020-2025 Päike Mikrosüsteemid OÜ. All rights reserved.
 //
 
 /// Chess game.
@@ -256,6 +257,39 @@ public class Game {
     }
 
     // MARK: Utilities
+
+    /**
+     Returns the current game position with the correct en-passant field.
+    
+     According to the FEN format specification:
+    
+     ```
+     The en passant target square is specified after a double push of a pawn, no matter whether an en passant capture is really possible or not.
+     ```
+    
+     Use this function if you want to obtain a position with the correct en passant field, indicating whether an en passant capture is possible.
+    
+     For further details, refer to issue #11: https://github.com/aperechnev/ChessKit/issues/11.
+    
+     - Returns: A `Position` instance with correct `state.enPasant` field.
+    */
+    public func positionWithCorrectEnPassant() -> Position {
+        var position: Position = self.position
+
+        if position.state.enPasant == nil {
+            return position
+        }
+
+        let moves: [Move] = self.legalMoves.filter {
+            $0.to == position.state.enPasant && position.board[$0.from]?.kind == .pawn
+        }
+
+        if moves.isEmpty {
+            position.state.enPasant = nil
+        }
+
+        return position
+    }
 
     /**
      Creates a deep copy of current game.

--- a/Tests/ChessKitTests/IssueTests/Issue11.swift
+++ b/Tests/ChessKitTests/IssueTests/Issue11.swift
@@ -10,7 +10,7 @@ import Testing
 
 @testable import ChessKit
 
-func makePosition(afterMoves movesString: String) -> Position {
+func makePositionWithCorrectEnPassant(afterMoves movesString: String) -> Position {
     let fenSerializator: FenSerialization = FenSerialization()
     let initialFen: String = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
     let initialPosition: Position = fenSerializator.deserialize(fen: initialFen)
@@ -21,15 +21,28 @@ func makePosition(afterMoves movesString: String) -> Position {
         .map { Move(string: $0.description) }
 
     let game: Game = Game(position: initialPosition)
+    moves.forEach(game.make(move:))
 
-    moves.forEach { game.make(move: $0) }
-
-    return game.position
+    return game.positionWithCorrectEnPassant()
 }
 
-@Test("Issue #11")
-func issue11() {
-    let position1: Position = makePosition(afterMoves: "e2e4 e7e5 d2d4 d7d5")
-    let position2: Position = makePosition(afterMoves: "d2d4 d7d5 e2e4 e7e5")
+@Test("Positions with correct en-passant: both with no en-passant")
+func bothWithNoEnPassant() {
+    let position1: Position = makePositionWithCorrectEnPassant(afterMoves: "e2e4 e7e5 d2d4 d7d5")
+    let position2: Position = makePositionWithCorrectEnPassant(afterMoves: "d2d4 d7d5 e2e4 e7e5")
     #expect(position1 == position2, "\(position1) != \(position2)")
+}
+
+@Test("Positions with correct en-passant: one with en-passant")
+func oneWithEnPassant() {
+    let position1: Position = makePositionWithCorrectEnPassant(
+        afterMoves: "e2e4 b7b5 h2h3 h7h6 a2a4 b5b4 e4e5")
+    let position2: Position = makePositionWithCorrectEnPassant(
+        afterMoves: "e2e4 b7b5 e4e5 h7h6 h2h3 b5b4 a2a4")
+
+    #expect(position1 != position2, "\(position1) == \(position2)")
+    #expect(position1.state.enPasant == nil)
+    #expect(
+        position2.state.enPasant?.description == "a3",
+        "En-passant: \(position2.state.enPasant?.description ?? "nil")")
 }

--- a/Tests/ChessKitTests/IssueTests/Issue11.swift
+++ b/Tests/ChessKitTests/IssueTests/Issue11.swift
@@ -10,7 +10,7 @@ import Testing
 
 @testable import ChessKit
 
-func makeFen(afterMoves movesString: String) -> String {
+func makePosition(afterMoves movesString: String) -> Position {
     let fenSerializator: FenSerialization = FenSerialization()
     let initialFen: String = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
     let initialPosition: Position = fenSerializator.deserialize(fen: initialFen)
@@ -24,12 +24,12 @@ func makeFen(afterMoves movesString: String) -> String {
 
     moves.forEach { game.make(move: $0) }
 
-    return fenSerializator.serialize(position: game.position)
+    return game.position
 }
 
 @Test("Issue #11")
 func issue11() {
-    let fen1 = makeFen(afterMoves: "e2e4 e7e5 d2d4 d7d5")
-    let fen2 = makeFen(afterMoves: "d2d4 d7d5 e2e4 e7e5")
-    #expect(fen1 == fen2, "\(fen1) != \(fen2)")
+    let position1: Position = makePosition(afterMoves: "e2e4 e7e5 d2d4 d7d5")
+    let position2: Position = makePosition(afterMoves: "d2d4 d7d5 e2e4 e7e5")
+    #expect(position1 == position2, "\(position1) != \(position2)")
 }

--- a/Tests/ChessKitTests/IssueTests/Issue11.swift
+++ b/Tests/ChessKitTests/IssueTests/Issue11.swift
@@ -1,0 +1,35 @@
+//
+//  Issue11.swift
+//  ChessKitTests
+//
+//  Created by Alexander Perechnev, 2025.
+//  Copyright © 2025 Päike Mikrosüsteemid OÜ. All rights reserved.
+//
+
+import Testing
+
+@testable import ChessKit
+
+func makeFen(afterMoves movesString: String) -> String {
+    let fenSerializator: FenSerialization = FenSerialization()
+    let initialFen: String = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+    let initialPosition: Position = fenSerializator.deserialize(fen: initialFen)
+
+    let moves: [Move] =
+        movesString
+        .split(separator: " ")
+        .map { Move(string: $0.description) }
+
+    let game: Game = Game(position: initialPosition)
+
+    moves.forEach { game.make(move: $0) }
+
+    return fenSerializator.serialize(position: game.position)
+}
+
+@Test("Issue #11")
+func issue11() {
+    let fen1 = makeFen(afterMoves: "e2e4 e7e5 d2d4 d7d5")
+    let fen2 = makeFen(afterMoves: "d2d4 d7d5 e2e4 e7e5")
+    #expect(fen1 == fen2, "\(fen1) != \(fen2)")
+}


### PR DESCRIPTION
The test fails saying that the positions aren't equal:

1. `rnbqkbnr/ppp2ppp/8/3pp3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq d6 0 3`
2. `rnbqkbnr/ppp2ppp/8/3pp3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq e6 0 3`